### PR TITLE
feat(brigadier): rework client-side command tree mapping

### DIFF
--- a/brigadier/src/main/java/eu/okaeri/commands/brigadier/CommandsBrigadierBase.java
+++ b/brigadier/src/main/java/eu/okaeri/commands/brigadier/CommandsBrigadierBase.java
@@ -1,10 +1,11 @@
 package eu.okaeri.commands.brigadier;
 
+import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.*;
+import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.tree.ArgumentCommandNode;
 import com.mojang.brigadier.tree.CommandNode;
-import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
 import eu.okaeri.commands.OkaeriCommands;
 import eu.okaeri.commands.brigadier.annotation.BrigadierDisabled;
@@ -14,12 +15,15 @@ import eu.okaeri.commands.meta.CommandMeta;
 import eu.okaeri.commands.meta.ExecutorMeta;
 import eu.okaeri.commands.meta.ServiceMeta;
 import eu.okaeri.commands.meta.pattern.PatternMeta;
+import eu.okaeri.commands.meta.pattern.element.OptionalElement;
 import eu.okaeri.commands.meta.pattern.element.PatternElement;
 import eu.okaeri.commands.meta.pattern.element.StaticElement;
 import eu.okaeri.commands.service.CommandData;
 import eu.okaeri.commands.service.Invocation;
 
+import java.lang.reflect.Field;
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -32,6 +36,9 @@ public class CommandsBrigadierBase {
 
     private static final boolean TRACE = Boolean.parseBoolean(System.getProperty("okaeri.platform.trace", "false"));
     private static final Logger LOGGER = Logger.getLogger(CommandsBrigadierBase.class.getSimpleName());
+
+    private static final Command<Object> NOOP = context -> Command.SINGLE_SUCCESS;
+    private static final List<Field> CHILD_FIELDS = resolveChildFields();
 
     protected final Map<Class<?>, ArgumentType<?>> argumentTypes = new HashMap<>();
     protected final Set<Class<?>> staticTypes = new HashSet<>();
@@ -55,7 +62,7 @@ public class CommandsBrigadierBase {
         this.staticTypes.add(Boolean.class);
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void update(CommandData data, RootCommandNode commandNode) {
 
         // delay dumping all labels to first player
@@ -92,31 +99,38 @@ public class CommandsBrigadierBase {
             ArgumentCommandNode args = (ArgumentCommandNode) argsChild;
             SuggestionProvider askServerSuggestion = args.getCustomSuggestions();
 
+            // nodes without a command are rendered as unknown by the client,
+            // so every complete path needs to carry the original one over
+            Command executes = firstNonNull(args.getCommand(), oldNode.getCommand(), NOOP);
+
             // get metas for label
             List<CommandMeta> metas = this.commands.findByLabel(label);
             if (metas.isEmpty()) {
                 continue;
             }
 
-            // check access (permissions)
-            ServiceMeta service = metas.get(0).getService();
-            Invocation dummyContext = Invocation.of(service, service.getLabel(), new String[0]);
-            if (!this.commands.getAccessHandler().allowAccess(service, dummyContext, data, false)) {
-                continue;
-            }
-
-            // brigadier support is disabled for this service
-            if (service.getImplementor().getClass().isAnnotationPresent(BrigadierDisabled.class)) {
+            // any service behind this label opting out keeps the plain ask_server node
+            boolean disabled = metas.stream()
+                .map(meta -> meta.getService().getImplementor().getClass())
+                .anyMatch(implementor -> implementor.isAnnotationPresent(BrigadierDisabled.class));
+            if (disabled) {
                 continue;
             }
 
             // clear current node
-            oldNode.getChildren().clear();
+            clearChildren(oldNode);
             for (CommandMeta meta : metas) {
 
                 // we may need that later
+                ServiceMeta service = meta.getService();
                 ExecutorMeta executor = meta.getExecutor();
                 PatternMeta pattern = executor.getPattern();
+
+                // check access (permissions)
+                Invocation serviceInvocation = Invocation.of(service, service.getLabel(), new String[0]);
+                if (!this.commands.getAccessHandler().allowAccess(service, serviceInvocation, data, false)) {
+                    continue;
+                }
 
                 // check access
                 Invocation invocation = Invocation.of(meta, service.getLabel(), "");
@@ -125,17 +139,20 @@ public class CommandsBrigadierBase {
                 }
 
                 // track tree position
+                List<PatternElement> elements = pattern.getElements();
                 List<CommandNode> currentNodes = new ArrayList<>(Collections.singletonList(oldNode));
 
                 // transform pattern elements into nodes
-                for (PatternElement patternElement : pattern.getElements()) {
+                for (int index = 0; index < elements.size(); index++) {
+
+                    PatternElement patternElement = elements.get(index);
+
+                    // the command is complete here when nothing but optionals follow
+                    Command command = terminates(elements, index) ? executes : null;
 
                     // static elements are easy, just use literal
                     if (patternElement instanceof StaticElement) {
-                        LiteralCommandNode<Object> literal = literal(patternElement.getName()).build();
-                        currentNodes.forEach(node -> node.addChild(literal));
-                        currentNodes.clear();
-                        currentNodes.add(literal);
+                        currentNodes = this.attach(currentNodes, () -> literal(patternElement.getName()).executes(command).build());
                         continue;
                     }
 
@@ -152,63 +169,179 @@ public class CommandsBrigadierBase {
                             // dynamic completion
                             if (completion.startsWith("@")) {
                                 ArgumentType type = this.resolveType(argumentMeta, patternElement);
-                                ArgumentCommandNode argument = argument(patternElement.getName(), type).suggests(askServerSuggestion).build();
-                                currentNodes.forEach(node -> node.addChild(argument));
-                                newNodes.add(argument);
+                                addDistinct(newNodes, this.attach(currentNodes, () -> argument(patternElement.getName(), type).suggests(askServerSuggestion).executes(command).build()));
                             }
                             // static completion
                             else {
-                                LiteralCommandNode<Object> literal = literal(completion).build();
-                                currentNodes.forEach(node -> node.addChild(literal));
-                                newNodes.add(literal);
+                                addDistinct(newNodes, this.attach(currentNodes, () -> literal(completion).executes(command).build()));
                             }
                         }
                         // update current nodes with new list
-                        currentNodes.clear();
-                        currentNodes.addAll(newNodes);
+                        currentNodes = newNodes;
                         continue;
                     }
 
                     // try generating static completions
-                    if (argumentMeta != null) {
+                    if ((argumentMeta != null) && this.canAssumeStatic(argumentMeta.getType())) {
 
-                        // get already resolved type
-                        Class<?> type = argumentMeta.getType();
-
-                        // only certain types can be assumed as static
-                        if (this.canAssumeStatic(type)) {
-                            // resolve completions using completion handler
-                            List<String> argumentCompletions;
-                            NamedCompletionHandler typeCompletionHandler = this.commands.getTypeCompletionHandlers().get(argumentMeta.getType());
-                            if (typeCompletionHandler != null) {
-                                argumentCompletions = typeCompletionHandler.complete(executor.getCompletion(), argumentMeta, invocation, data);
-                            } else {
-                                argumentCompletions = this.commands.getCompletionHandler().complete(argumentMeta, invocation, data);
-                            }
-                            // this section bifurcates so we need to track it separately
-                            List<CommandNode> newNodes = new ArrayList<>();
-                            // every completion needs to be added separately
-                            for (String completion : argumentCompletions) {
-                                LiteralCommandNode<Object> literal = literal(completion).build();
-                                currentNodes.forEach(node -> node.addChild(literal));
-                                newNodes.add(literal);
-                            }
-                            // update current nodes with new list
-                            currentNodes.clear();
-                            currentNodes.addAll(newNodes);
-                            continue;
+                        // resolve completions using completion handler
+                        List<String> argumentCompletions;
+                        NamedCompletionHandler typeCompletionHandler = this.commands.getTypeCompletionHandlers().get(argumentMeta.getType());
+                        if (typeCompletionHandler != null) {
+                            argumentCompletions = typeCompletionHandler.complete(executor.getCompletion(), argumentMeta, invocation, data);
+                        } else {
+                            argumentCompletions = this.commands.getCompletionHandler().complete(argumentMeta, invocation, data);
                         }
+
+                        // this section bifurcates so we need to track it separately
+                        List<CommandNode> newNodes = new ArrayList<>();
+                        // every completion needs to be added separately
+                        for (String completion : argumentCompletions) {
+                            addDistinct(newNodes, this.attach(currentNodes, () -> literal(completion).executes(command).build()));
+                        }
+
+                        // these completions are derived from the type and the resolver behind
+                        // it takes more than they list (any case, and yes/on/1 for booleans),
+                        // so an argument node keeps the client from rejecting valid input.
+                        // deliberately without the meta: the mapped type would be just as
+                        // narrow as the literals it is meant to widen
+                        ArgumentType fallbackType = this.resolveType(null, patternElement);
+                        addDistinct(newNodes, this.attach(currentNodes, () -> argument(patternElement.getName(), fallbackType).suggests(askServerSuggestion).executes(command).build()));
+
+                        // update current nodes with new list
+                        currentNodes = newNodes;
+                        continue;
                     }
 
                     // dynamic elements may be complicated, use ask_server
                     ArgumentType type = this.resolveType(argumentMeta, patternElement);
-                    ArgumentCommandNode argument = argument(patternElement.getName(), type).suggests(askServerSuggestion).build();
-                    currentNodes.forEach(node -> node.addChild(argument));
-                    currentNodes.clear();
-                    currentNodes.add(argument);
+
+                    // a wider element stands for that many arguments and brigadier
+                    // has no notion of it, so it takes one node per consumed argument
+                    int width = Math.max(patternElement.getWidth(), 1);
+                    for (int token = 0; token < width; token++) {
+                        Command last = ((token + 1) == width) ? command : null;
+                        currentNodes = this.attach(currentNodes, () -> argument(patternElement.getName(), type).suggests(askServerSuggestion).executes(last).build());
+                    }
                 }
             }
         }
+    }
+
+    /**
+     * Adds a freshly built node under every current node and returns the nodes
+     * the tree actually ended up with, which is what the next pattern element
+     * has to be attached to.
+     */
+    @SuppressWarnings("rawtypes")
+    protected List<CommandNode> attach(List<CommandNode> parents, Supplier<CommandNode> factory) {
+        List<CommandNode> attached = new ArrayList<>();
+        for (CommandNode parent : parents) {
+            addDistinct(attached, Collections.singletonList(this.merge(parent, factory.get())));
+        }
+        return attached;
+    }
+
+    /**
+     * Brigadier merges same-named children onto the node already present in the
+     * tree and discards the instance passed to addChild. Building further
+     * elements on the discarded node silently drops whole executor branches,
+     * so the node that ended up in the tree has to be handed back instead.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected CommandNode merge(CommandNode parent, CommandNode node) {
+
+        CommandNode existing = parent.getChild(node.getName());
+        if (existing == null) {
+            parent.addChild(node);
+            return node;
+        }
+
+        // sibling patterns may describe the same argument with different types
+        // and a single node cannot represent both, so no client side type is
+        // used at all: a plain word accepts whatever any of the branches takes
+        // and the suggestions were being asked of the server anyway
+        if (this.conflicting(existing, node) && !this.isWord(existing)) {
+            return this.replaceChild(parent, existing, this.generic(existing, node));
+        }
+
+        // merges the command and (still empty) children onto the existing node
+        parent.addChild(node);
+        return existing;
+    }
+
+    /**
+     * Swaps a child for another, carrying over its command and subtree.
+     * Brigadier has no removal API, hence the rebuild of the whole child list.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected CommandNode replaceChild(CommandNode parent, CommandNode old, CommandNode replacement) {
+
+        ArgumentBuilder builder = replacement.createBuilder();
+        if (replacement.getCommand() == null) {
+            builder.executes(old.getCommand());
+        }
+        old.getChildren().forEach(child -> builder.then((CommandNode) child));
+        CommandNode merged = builder.build();
+
+        List<CommandNode> siblings = new ArrayList<>(parent.getChildren());
+        clearChildren(parent);
+        for (CommandNode sibling : siblings) {
+            parent.addChild((sibling == old) ? merged : sibling);
+        }
+
+        return merged;
+    }
+
+    /**
+     * Whether two same-named nodes describe the same argument in a way a single
+     * node can express. A literal never conflicts: it is matched before any
+     * argument, so both still parse.
+     */
+    @SuppressWarnings("rawtypes")
+    protected boolean conflicting(CommandNode existing, CommandNode node) {
+
+        if (!(existing instanceof ArgumentCommandNode) || !(node instanceof ArgumentCommandNode)) {
+            return false;
+        }
+
+        ArgumentType<?> existingType = ((ArgumentCommandNode) existing).getType();
+        ArgumentType<?> nodeType = ((ArgumentCommandNode) node).getType();
+
+        if (existingType.getClass() != nodeType.getClass()) {
+            return true;
+        }
+
+        // greedy and single word are the same class but consume differently
+        return (existingType instanceof StringArgumentType)
+            && (((StringArgumentType) existingType).getType() != ((StringArgumentType) nodeType).getType());
+    }
+
+    @SuppressWarnings("rawtypes")
+    protected boolean isWord(CommandNode node) {
+        return (node instanceof ArgumentCommandNode)
+            && (((ArgumentCommandNode) node).getType() instanceof StringArgumentType)
+            && (((StringArgumentType) ((ArgumentCommandNode) node).getType()).getType() == StringArgumentType.StringType.SINGLE_WORD);
+    }
+
+    /**
+     * The untyped node two conflicting ones fall back to. A single word rather
+     * than a greedy one even when a branch was greedy: greedy would swallow the
+     * elements the other branch still has to suggest.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected CommandNode generic(CommandNode existing, CommandNode node) {
+
+        SuggestionProvider suggestions = firstNonNull(
+            ((ArgumentCommandNode) node).getCustomSuggestions(),
+            ((ArgumentCommandNode) existing).getCustomSuggestions());
+
+        Command command = firstNonNull(node.getCommand(), existing.getCommand());
+
+        return argument(node.getName(), StringArgumentType.word())
+            .suggests(suggestions)
+            .executes(command)
+            .build();
     }
 
     protected ArgumentType resolveType(ArgumentMeta argument, PatternElement patternElement) {
@@ -232,5 +365,70 @@ public class CommandsBrigadierBase {
             return true;
         }
         return this.staticTypes.contains(type);
+    }
+
+    private static boolean terminates(List<PatternElement> elements, int index) {
+        for (int i = index + 1; i < elements.size(); i++) {
+            if (!(elements.get(i) instanceof OptionalElement)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static void addDistinct(List<CommandNode> target, Collection<CommandNode> nodes) {
+        for (CommandNode node : nodes) {
+            if (target.stream().noneMatch(present -> present == node)) {
+                target.add(node);
+            }
+        }
+    }
+
+    /**
+     * {@code getChildren().clear()} only empties one of the three maps a
+     * CommandNode keeps; the literals/arguments indexes brigadier parses
+     * through would keep matching the removed nodes.
+     */
+    @SuppressWarnings("rawtypes")
+    protected static void clearChildren(CommandNode node) {
+
+        if (CHILD_FIELDS.isEmpty()) {
+            node.getChildren().clear();
+            return;
+        }
+
+        try {
+            for (Field field : CHILD_FIELDS) {
+                ((Map<?, ?>) field.get(node)).clear();
+            }
+        } catch (IllegalAccessException exception) {
+            throw new IllegalStateException("Failed to clear children of " + node.getName(), exception);
+        }
+    }
+
+    private static List<Field> resolveChildFields() {
+        List<Field> fields = new ArrayList<>();
+        for (String name : new String[]{"children", "literals", "arguments"}) {
+            try {
+                Field field = CommandNode.class.getDeclaredField(name);
+                field.setAccessible(true);
+                fields.add(field);
+            } catch (Exception exception) {
+                LOGGER.warning("Unsupported brigadier version, stale command nodes may remain: " + exception);
+                return Collections.emptyList();
+            }
+        }
+        return fields;
+    }
+
+    @SafeVarargs
+    private static <T> T firstNonNull(T... values) {
+        for (T value : values) {
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
     }
 }

--- a/brigadier/src/test/java/eu/okaeri/commands/brigadier/BrigadierTestHarness.java
+++ b/brigadier/src/test/java/eu/okaeri/commands/brigadier/BrigadierTestHarness.java
@@ -1,0 +1,178 @@
+package eu.okaeri.commands.brigadier;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.suggestion.Suggestion;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.tree.ArgumentCommandNode;
+import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.tree.RootCommandNode;
+import eu.okaeri.commands.OkaeriCommands;
+import eu.okaeri.commands.meta.CommandMeta;
+import eu.okaeri.commands.service.CommandData;
+import eu.okaeri.commands.service.CommandService;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.mojang.brigadier.builder.LiteralArgumentBuilder.literal;
+
+/**
+ * Test-only stand-in for the Paper integration. Builds the same
+ * {@link RootCommandNode} shape that CraftBukkit hands to
+ * AsyncPlayerSendCommandsEvent (a label literal with a single greedy
+ * "args" child suggesting ask_server) and then runs the real
+ * {@link CommandsBrigadierBase#update} against it.
+ */
+final class BrigadierTestHarness extends CommandsBrigadierBase {
+
+    static final String ASK_SERVER = "<ask_server>";
+
+    private static final SuggestionProvider<Object> ASK_SERVER_SUGGESTION =
+        (context, builder) -> builder.suggest(ASK_SERVER).buildFuture();
+
+    private final RootCommandNode<Object> root = new RootCommandNode<>();
+    private final CommandData data = new CommandData();
+
+    private BrigadierTestHarness(OkaeriCommands commands) {
+        this.commands = commands;
+    }
+
+    @SafeVarargs
+    static BrigadierTestHarness of(Class<? extends CommandService>... services) {
+        OkaeriCommands commands = new OkaeriCommands();
+        for (Class<? extends CommandService> service : services) {
+            commands.registerCommand(service);
+        }
+        return new BrigadierTestHarness(commands);
+    }
+
+    /**
+     * Recreates the bukkit-generated nodes and applies the brigadier mapping,
+     * mirroring what happens on every AsyncPlayerSendCommandsEvent.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    BrigadierTestHarness update() {
+
+        this.labels()
+            .filter(label -> this.root.getChild(label) == null)
+            .forEach(label -> this.root.addChild(literal(label)
+                .then(RequiredArgumentBuilder.<Object, String>argument("args", StringArgumentType.greedyString())
+                    .suggests(ASK_SERVER_SUGGESTION))
+                .build()));
+
+        this.update(this.data, (RootCommandNode) this.root);
+        return this;
+    }
+
+    /**
+     * Every root-to-leaf path in the tree, rendered as space separated usage
+     * text ("quest assign &lt;target&gt;"). Sorted for stable comparison.
+     */
+    List<String> paths() {
+        return this.paths(CommandNode::getChildren);
+    }
+
+    /**
+     * The same, but walked through the internal literals/arguments indexes.
+     * Brigadier parses through those and {@code getChildren().clear()} does not
+     * empty them, so a path here that is missing from {@link #paths()} is a
+     * node that was supposed to be gone.
+     */
+    List<String> parsablePaths() {
+        return this.paths(BrigadierTestHarness::indexed);
+    }
+
+    /**
+     * Whether brigadier considers the input a complete, runnable command.
+     * The client greys out anything that is not.
+     */
+    boolean executable(String input) {
+        try {
+            this.dispatcher().execute(input, new Object());
+            return true;
+        } catch (CommandSyntaxException exception) {
+            return false;
+        }
+    }
+
+    List<String> suggest(String input) {
+        CommandDispatcher<Object> dispatcher = this.dispatcher();
+        try {
+            return dispatcher.getCompletionSuggestions(dispatcher.parse(input, new Object())).get()
+                .getList().stream()
+                .map(Suggestion::getText)
+                .sorted()
+                .collect(Collectors.toList());
+        } catch (InterruptedException | ExecutionException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    /**
+     * The same engine the tree was built from, to check the mapping against
+     * what the server itself accepts and completes.
+     */
+    OkaeriCommands commands() {
+        return this.commands;
+    }
+
+    private CommandDispatcher<Object> dispatcher() {
+        return new CommandDispatcher<>(this.root);
+    }
+
+    private Stream<String> labels() {
+        return this.commands.getRegisteredCommands().stream()
+            .map(CommandMeta::getService)
+            .flatMap(service -> Stream.concat(Stream.of(service.getLabel()), service.getAliases().stream()))
+            .distinct();
+    }
+
+    private List<String> paths(Function<CommandNode<Object>, Collection<CommandNode<Object>>> children) {
+        List<String> paths = new ArrayList<>();
+        for (CommandNode<Object> child : children.apply(this.root)) {
+            collect(child, "", children, paths);
+        }
+        Collections.sort(paths);
+        return paths;
+    }
+
+    private static void collect(CommandNode<Object> node, String prefix, Function<CommandNode<Object>, Collection<CommandNode<Object>>> children, List<String> out) {
+
+        String name = (node instanceof ArgumentCommandNode) ? ("<" + node.getName() + ">") : node.getName();
+        String path = prefix.isEmpty() ? name : (prefix + " " + name);
+
+        Collection<CommandNode<Object>> nodes = children.apply(node);
+        if (nodes.isEmpty()) {
+            out.add(path);
+            return;
+        }
+
+        for (CommandNode<Object> child : nodes) {
+            collect(child, path, children, out);
+        }
+    }
+
+    private static Collection<CommandNode<Object>> indexed(CommandNode<Object> node) {
+        List<CommandNode<Object>> nodes = new ArrayList<>(index(node, "literals"));
+        nodes.addAll(index(node, "arguments"));
+        return nodes;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Collection<CommandNode<Object>> index(CommandNode<Object> node, String name) {
+        try {
+            Field field = CommandNode.class.getDeclaredField(name);
+            field.setAccessible(true);
+            return ((Map<String, CommandNode<Object>>) field.get(node)).values();
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Failed to read " + name + " of " + node.getName(), exception);
+        }
+    }
+}

--- a/brigadier/src/test/java/eu/okaeri/commands/brigadier/TestBrigadierParity.java
+++ b/brigadier/src/test/java/eu/okaeri/commands/brigadier/TestBrigadierParity.java
@@ -1,0 +1,157 @@
+package eu.okaeri.commands.brigadier;
+
+import eu.okaeri.commands.service.CommandService;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static eu.okaeri.commands.brigadier.BrigadierTestHarness.ASK_SERVER;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The brigadier tree is a client-side model of what the server will accept.
+ * Where the two disagree the player is told a command is wrong when it is not,
+ * or the other way around, so every shape covered by {@link TestBrigadierTree}
+ * is checked against the engine that actually runs it.
+ */
+public final class TestBrigadierParity {
+
+    private static void assertAccepts(Class<? extends CommandService> service, String... inputs) {
+        assertAccepts(BrigadierTestHarness.of(service).update(), inputs);
+    }
+
+    private static void assertAccepts(BrigadierTestHarness harness, String... inputs) {
+        for (String input : inputs) {
+            assertEquals(harness.commands().invocationMatch(input).isPresent(), harness.executable(input),
+                "client and server disagree about '" + input + "'");
+        }
+    }
+
+    private static void assertSuggests(Class<? extends CommandService> service, String... inputs) {
+        assertSuggests(BrigadierTestHarness.of(service).update(), inputs);
+    }
+
+    private static void assertSuggests(BrigadierTestHarness harness, String... inputs) {
+        for (String input : inputs) {
+
+            List<String> server = harness.commands().complete(input);
+            List<String> client = harness.suggest(input);
+
+            // an ask_server node means the client defers for this argument, so
+            // whatever it offers by itself only has to be part of the answer
+            if (client.remove(ASK_SERVER)) {
+                assertTrue(server.containsAll(client),
+                    "client offers completions the server does not for '" + input + "': " + client + " vs " + server);
+                continue;
+            }
+
+            assertIterableEquals(server, client, "client and server disagree about completions for '" + input + "'");
+        }
+    }
+
+    @Test
+    public void test_sibling_patterns() {
+        assertAccepts(TestBrigadierTree.MultiPatternCommand.class,
+            "multi", "multi something", "multi something abc",
+            "multi something abc something1", "multi something abc something4", "multi something abc something1 extra");
+    }
+
+    @Test
+    public void test_mixed_literal_and_argument() {
+        assertAccepts(TestBrigadierTree.QuestCommand.class,
+            "quest", "quest assign", "quest assign player1", "quest assign player1 q1",
+            "quest assign player1 q1 q2", "quest assign @a q1 q2");
+    }
+
+    /**
+     * Known divergence. Brigadier matches a literal before any sibling argument
+     * and never backtracks, so an input equal to another pattern's literal can
+     * only be read as that pattern. The server tries every pattern and still
+     * reaches the argument, which makes the client the stricter of the two.
+     */
+    @Test
+    public void test_literal_shadows_a_sibling_argument() {
+
+        BrigadierTestHarness harness = BrigadierTestHarness.of(TestBrigadierTree.QuestCommand.class).update();
+
+        assertTrue(harness.commands().invocationMatch("quest assign @a q1").isPresent(), "the server reads @a as the target");
+        assertFalse(harness.executable("quest assign @a q1"), "the client can only read @a as the literal");
+    }
+
+    /**
+     * Known divergence. A greedy element next to a single word one for the same
+     * argument collapses to a word, so the client stops accepting the rest of
+     * the line the greedy branch would have taken.
+     */
+    @Test
+    public void test_greedy_conflict_narrows_the_client() {
+
+        BrigadierTestHarness harness = BrigadierTestHarness.of(TestBrigadierTree.ConflictingGreedyCommand.class).update();
+
+        assertTrue(harness.commands().invocationMatch("say hello world").isPresent(), "the server takes the whole message");
+        assertFalse(harness.executable("say hello world"), "the client stops after one word");
+    }
+
+    @Test
+    public void test_differing_arity() {
+        assertAccepts(TestBrigadierTree.VaryingArityCommand.class,
+            "vary something abc something1", "vary something abc something1 req", "vary something abc something1 req opt",
+            "vary something abc something2", "vary something abc something2 req", "vary something abc something2 req extra");
+    }
+
+    @Test
+    public void test_aliases() {
+        assertAccepts(TestBrigadierTree.AliasedCommand.class, "alias one", "ali one", "alias three");
+    }
+
+    @Test
+    public void test_conflicting_types() {
+        assertAccepts(TestBrigadierTree.ConflictingTypesCommand.class,
+            "wide set abc", "wide set 5", "wide set 5 kg", "wide set abc kg", "wide set 5 kg extra");
+    }
+
+    @Test
+    public void test_conflicting_numeric_types() {
+        assertAccepts(TestBrigadierTree.ConflictingNumbersCommand.class,
+            "num set 5", "num set 1.5", "num set abc", "num set 5 kg");
+    }
+
+    @Test
+    public void test_wide_elements() {
+        assertAccepts(TestBrigadierTree.WideElementCommand.class,
+            "wid set 1 2 now", "wid set 1 now", "wid set 1", "wid set 1 2", "wid set 1 2 now extra");
+    }
+
+    @Test
+    public void test_nested_services() {
+        assertAccepts(TestBrigadierTree.NestedParentCommand.class,
+            "nest top", "nest child deep x", "nest child deep", "nest child", "nest nope");
+    }
+
+    @Test
+    public void test_services_sharing_a_label() {
+
+        BrigadierTestHarness harness = BrigadierTestHarness.of(
+            TestBrigadierTree.SharedFirstCommand.class, TestBrigadierTree.SharedSecondCommand.class).update();
+
+        assertAccepts(harness, "shared first a", "shared second b", "shared first", "shared third c");
+        assertSuggests(harness, "shared ", "shared f");
+    }
+
+    @Test
+    public void test_static_completions_match_the_server() {
+        assertSuggests(TestBrigadierTree.CompletionCommand.class, "comp set ", "comp set a");
+    }
+
+    @Test
+    public void test_enum_completions_match_the_server() {
+        assertSuggests(TestBrigadierTree.EnumCommand.class, "en mode ", "en mode s");
+        assertAccepts(TestBrigadierTree.EnumCommand.class, "en mode survival", "en mode SURVIVAL", "en mode nope", "en mode");
+    }
+
+    @Test
+    public void test_boolean_completions_match_the_server() {
+        assertSuggests(TestBrigadierTree.BooleanCommand.class, "bool flag ", "bool flag t");
+        assertAccepts(TestBrigadierTree.BooleanCommand.class, "bool flag true", "bool flag YES", "bool flag 1", "bool flag");
+    }
+}

--- a/brigadier/src/test/java/eu/okaeri/commands/brigadier/TestBrigadierTree.java
+++ b/brigadier/src/test/java/eu/okaeri/commands/brigadier/TestBrigadierTree.java
@@ -1,0 +1,486 @@
+package eu.okaeri.commands.brigadier;
+
+import eu.okaeri.commands.annotation.Arg;
+import eu.okaeri.commands.annotation.Command;
+import eu.okaeri.commands.annotation.Completion;
+import eu.okaeri.commands.annotation.Executor;
+import eu.okaeri.commands.annotation.NestedCommand;
+import eu.okaeri.commands.brigadier.annotation.BrigadierDisabled;
+import eu.okaeri.commands.handler.access.DefaultAccessHandler;
+import eu.okaeri.commands.meta.ExecutorMeta;
+import eu.okaeri.commands.meta.ServiceMeta;
+import eu.okaeri.commands.service.CommandData;
+import eu.okaeri.commands.service.CommandService;
+import eu.okaeri.commands.service.Invocation;
+import eu.okaeri.commands.service.Option;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static eu.okaeri.commands.brigadier.BrigadierTestHarness.ASK_SERVER;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.*;
+
+public final class TestBrigadierTree {
+
+    private static BrigadierTestHarness tree(Class<? extends CommandService> service) {
+        return BrigadierTestHarness.of(service).update();
+    }
+
+    // https://github.com/OkaeriPoland/okaeri-commands/issues/7
+    @Test
+    public void test_sibling_patterns_all_present() {
+
+        assertIterableEquals(asList(
+            "multi something <value> something1",
+            "multi something <value> something2",
+            "multi something <value> something3"
+        ), tree(MultiPatternCommand.class).paths());
+    }
+
+    // https://github.com/OkaeriPoland/okaeri-commands/issues/7 (comment: real-life example)
+    @Test
+    public void test_sibling_patterns_mixed_literal_and_argument() {
+
+        assertIterableEquals(asList(
+            "quest assign <target> <quest> <requires>",
+            "quest assign @a <quest> <requires>"
+        ), tree(QuestCommand.class).paths());
+    }
+
+    // https://github.com/OkaeriPoland/okaeri-commands/issues/7 (patterns of differing arity)
+    @Test
+    public void test_sibling_patterns_differing_arity() {
+
+        assertIterableEquals(asList(
+            "vary something <value> something1 <required1> <optional1>",
+            "vary something <value> something2 <required1>"
+        ), tree(VaryingArityCommand.class).paths());
+    }
+
+    @Test
+    public void test_aliases_get_the_same_tree() {
+
+        assertIterableEquals(asList(
+            "ali one",
+            "ali two",
+            "alias one",
+            "alias two"
+        ), tree(AliasedCommand.class).paths());
+    }
+
+    @Test
+    public void test_dynamic_completions_use_ask_server() {
+
+        BrigadierTestHarness harness = tree(DynamicCompletionCommand.class);
+
+        assertIterableEquals(singletonList("dyn load <name>"), harness.paths());
+        assertIterableEquals(singletonList(ASK_SERVER), harness.suggest("dyn load "));
+    }
+
+    /**
+     * Type derived completions are offered as literals for the client to filter
+     * on its own, but the resolver behind them accepts more than they list
+     * (any case), so an argument node has to sit beside them.
+     */
+    @Test
+    public void test_enum_arguments_become_literals_plus_a_fallback() {
+
+        BrigadierTestHarness harness = tree(EnumCommand.class);
+
+        assertIterableEquals(asList("en mode <mode>", "en mode adventure", "en mode creative", "en mode survival"), harness.paths());
+        assertIterableEquals(asList(ASK_SERVER, "adventure", "creative", "survival"), harness.suggest("en mode "));
+        assertTrue(harness.executable("en mode SURVIVAL"), "the resolver is case insensitive");
+    }
+
+    @Test
+    public void test_boolean_arguments_become_literals_plus_a_fallback() {
+
+        BrigadierTestHarness harness = tree(BooleanCommand.class);
+
+        assertIterableEquals(asList("bool flag <on>", "bool flag false", "bool flag true"), harness.paths());
+        assertTrue(harness.executable("bool flag yes"), "the resolver takes yes/on/1 too");
+    }
+
+    /**
+     * An explicitly written completion list is the author's choice, so it stays
+     * a plain set of literals with nothing beside it.
+     */
+    @Test
+    public void test_written_completions_get_no_fallback() {
+
+        assertIterableEquals(asList("comp set allow", "comp set deny"), tree(CompletionCommand.class).paths());
+    }
+
+    /**
+     * Brigadier has no notion of an argument spanning several inputs, so a
+     * wider element takes one node per input it consumes.
+     */
+    @Test
+    public void test_wide_elements_take_one_node_each() {
+
+        assertIterableEquals(singletonList("wid set <coords> <coords> now"), tree(WideElementCommand.class).paths());
+    }
+
+    @Test
+    public void test_nested_services_hang_off_the_root_label() {
+
+        assertIterableEquals(asList("nest child deep <x>", "nest top"), tree(NestedParentCommand.class).paths());
+    }
+
+    @Test
+    public void test_denied_executors_are_left_out() {
+
+        BrigadierTestHarness harness = BrigadierTestHarness.of(MultiPatternCommand.class);
+        harness.commands().accessHandler(new DefaultAccessHandler() {
+            @Override
+            public boolean allowAccess(ExecutorMeta executor, Invocation invocation, CommandData data) {
+                return !executor.getPattern().getRaw().endsWith("something2");
+            }
+        });
+
+        assertIterableEquals(asList(
+            "multi something <value> something1",
+            "multi something <value> something3"
+        ), harness.update().paths());
+    }
+
+    @Test
+    public void test_services_sharing_a_label_merge_into_one_tree() {
+
+        BrigadierTestHarness harness = BrigadierTestHarness.of(SharedFirstCommand.class, SharedSecondCommand.class).update();
+
+        assertIterableEquals(asList("shared first <x>", "shared second <y>"), harness.paths());
+    }
+
+    /**
+     * The opt-out belongs to a service but the node belongs to the label, and
+     * one node cannot be half generated, so a single opting out service keeps
+     * the plain ask_server node for everything sharing that label.
+     */
+    @Test
+    public void test_one_disabled_service_disables_the_whole_label() {
+
+        BrigadierTestHarness harness = BrigadierTestHarness.of(SharedFirstCommand.class, SharedDisabledCommand.class).update();
+
+        assertIterableEquals(singletonList("shared <args>"), harness.paths());
+    }
+
+    @Test
+    public void test_access_is_checked_per_service() {
+
+        BrigadierTestHarness harness = BrigadierTestHarness.of(SharedFirstCommand.class, SharedSecondCommand.class);
+        harness.commands().accessHandler(new DefaultAccessHandler() {
+            @Override
+            public boolean allowAccess(ServiceMeta service, Invocation invocation, CommandData data, boolean checkExecutors) {
+                return !(service.getImplementor() instanceof SharedSecondCommand);
+            }
+        });
+
+        assertIterableEquals(singletonList("shared first <x>"), harness.update().paths());
+    }
+
+    @Test
+    public void test_disabled_service_keeps_the_generated_node() {
+
+        BrigadierTestHarness harness = tree(DisabledCommand.class);
+
+        assertIterableEquals(singletonList("dis <args>"), harness.paths());
+        assertIterableEquals(singletonList(ASK_SERVER), harness.suggest("dis "));
+    }
+
+    @Test
+    public void test_suggestions_follow_the_tree() {
+
+        BrigadierTestHarness harness = tree(MultiPatternCommand.class);
+
+        assertIterableEquals(singletonList("something"), harness.suggest("multi "));
+        assertIterableEquals(singletonList("something"), harness.suggest("multi some"));
+        assertIterableEquals(singletonList(ASK_SERVER), harness.suggest("multi something "));
+        assertIterableEquals(asList("something1", "something2", "something3"), harness.suggest("multi something abc "));
+        assertIterableEquals(asList("something1", "something2", "something3"), harness.suggest("multi something abc some"));
+    }
+
+    /**
+     * Nodes without a command render red on the client and are reported as
+     * unknown by brigadier's own parser.
+     */
+    @Test
+    public void test_complete_paths_are_executable() {
+
+        BrigadierTestHarness harness = tree(MultiPatternCommand.class);
+
+        assertTrue(harness.executable("multi something abc something1"));
+        assertFalse(harness.executable("multi something abc"), "the pattern is not complete yet");
+    }
+
+    @Test
+    public void test_optional_elements_may_be_omitted() {
+
+        BrigadierTestHarness harness = tree(VaryingArityCommand.class);
+
+        assertTrue(harness.executable("vary something abc something1 req"));
+        assertTrue(harness.executable("vary something abc something1 req opt"));
+        assertTrue(harness.executable("vary something abc something2 req"));
+    }
+
+    /**
+     * Sibling patterns naming the same argument collapse onto a single node.
+     * When they disagree on the type it is dropped rather than picked, leaving
+     * both the parsing and the completions to the server.
+     */
+    @Test
+    public void test_conflicting_argument_types_fall_back_to_the_server() {
+
+        BrigadierTestHarness harness = tree(ConflictingTypesCommand.class);
+
+        assertTrue(harness.executable("wide set abc"), "the String branch must still parse");
+        assertTrue(harness.executable("wide set 5 kg"), "the int branch must keep its children");
+        assertIterableEquals(singletonList(ASK_SERVER), harness.suggest("wide set "));
+    }
+
+    // neither branch is a string, so there is no widest type to fall back to
+    @Test
+    public void test_conflicting_numeric_types_fall_back_to_the_server() {
+
+        BrigadierTestHarness harness = tree(ConflictingNumbersCommand.class);
+
+        assertTrue(harness.executable("num set 5 kg"), "the int branch must keep its children");
+        assertTrue(harness.executable("num set 1.5"), "the double branch must still parse");
+        assertTrue(harness.executable("num set abc"), "neither type is enforced client side anymore");
+    }
+
+    // a greedy sibling must not swallow the elements another branch still suggests
+    @Test
+    public void test_greedy_conflicting_with_word_keeps_the_siblings_reachable() {
+
+        BrigadierTestHarness harness = tree(ConflictingGreedyCommand.class);
+
+        assertIterableEquals(singletonList("say <message> loud"), harness.paths());
+        assertIterableEquals(singletonList("loud"), harness.suggest("say hello "));
+        assertTrue(harness.executable("say hello"));
+        assertTrue(harness.executable("say hello loud"));
+    }
+
+    /**
+     * Brigadier parses through the internal literals/arguments indexes, which
+     * {@code getChildren().clear()} does not touch. Anything left there is
+     * still matched even though it is gone from the tree.
+     */
+    @Test
+    public void test_no_stale_nodes_left_behind() {
+
+        BrigadierTestHarness harness = tree(MultiPatternCommand.class);
+
+        assertIterableEquals(harness.paths(), harness.parsablePaths());
+        assertFalse(harness.suggest("multi ").contains(ASK_SERVER), "the replaced greedy args node is still reachable");
+    }
+
+    @Test
+    public void test_update_is_idempotent() {
+
+        BrigadierTestHarness harness = tree(MultiPatternCommand.class);
+        List<String> first = harness.paths();
+
+        harness.update();
+
+        assertIterableEquals(first, harness.paths());
+        assertIterableEquals(first, harness.parsablePaths());
+    }
+
+    @Command(label = "multi")
+    public static class MultiPatternCommand implements CommandService {
+
+        @Executor(pattern = {"something <value> something1", "something <value> something2", "something <value> something3"})
+        public String something(@Arg("value") String value) {
+            return value;
+        }
+    }
+
+    @Command(label = "quest")
+    public static class QuestCommand implements CommandService {
+
+        @Executor
+        public String assign(@Arg("target") String target, @Arg("quest") String quest, @Arg("requires") Option<String> requires) {
+            return quest;
+        }
+
+        @Executor(pattern = "assign @a <quest> <requires>")
+        public String assign_all(@Arg("quest") String quest, @Arg("requires") String requires) {
+            return quest;
+        }
+    }
+
+    @Command(label = "vary")
+    public static class VaryingArityCommand implements CommandService {
+
+        @Executor(pattern = "something <value> something1 <required1> [optional1]")
+        public String one(@Arg("value") String value, @Arg("required1") String required1, @Arg("optional1") Option<String> optional1) {
+            return value;
+        }
+
+        @Executor(pattern = "something <value> something2 <required1>")
+        public String two(@Arg("value") String value, @Arg("required1") String required1) {
+            return value;
+        }
+    }
+
+    @Command(label = "wide")
+    public static class ConflictingTypesCommand implements CommandService {
+
+        @Executor(pattern = "set <value> <unit>")
+        public String withUnit(@Arg("value") int value, @Arg("unit") String unit) {
+            return unit;
+        }
+
+        @Executor(pattern = "set <value>")
+        public String plain(@Arg("value") String value) {
+            return value;
+        }
+    }
+
+    @Command(label = "num")
+    public static class ConflictingNumbersCommand implements CommandService {
+
+        @Executor(pattern = "set <value> <unit>")
+        public String withUnit(@Arg("value") int value, @Arg("unit") String unit) {
+            return unit;
+        }
+
+        @Executor(pattern = "set <value>")
+        public String plain(@Arg("value") double value) {
+            return String.valueOf(value);
+        }
+    }
+
+    @Command(label = "say")
+    public static class ConflictingGreedyCommand implements CommandService {
+
+        @Executor(pattern = "<message...>")
+        public String greedy(@Arg("message") String message) {
+            return message;
+        }
+
+        @Executor(pattern = "<message> loud")
+        public String loud(@Arg("message") String message) {
+            return message;
+        }
+    }
+
+    @Command(label = "alias", aliases = "ali")
+    public static class AliasedCommand implements CommandService {
+
+        @Executor(pattern = {"one", "two"})
+        public String both() {
+            return "ok";
+        }
+    }
+
+    @Command(label = "comp")
+    public static class CompletionCommand implements CommandService {
+
+        @Executor(pattern = "set <state>")
+        @Completion(arg = "state", value = {"allow", "deny"})
+        public String set(@Arg("state") String state) {
+            return state;
+        }
+    }
+
+    @Command(label = "dyn")
+    public static class DynamicCompletionCommand implements CommandService {
+
+        @Executor(pattern = "load <name>")
+        @Completion(arg = "name", value = "@scripts")
+        public String load(@Arg("name") String name) {
+            return name;
+        }
+    }
+
+    @Command(label = "wid")
+    public static class WideElementCommand implements CommandService {
+
+        @Executor(pattern = "set <coords:2> now")
+        public String set(@Arg("coords") String coords) {
+            return coords;
+        }
+    }
+
+    @Command(label = "nest", nested = @NestedCommand(NestedChildCommand.class))
+    public static class NestedParentCommand implements CommandService {
+
+        @Executor(pattern = "top")
+        public String top() {
+            return "top";
+        }
+    }
+
+    @Command(label = "child")
+    public static class NestedChildCommand implements CommandService {
+
+        @Executor(pattern = "deep <x>")
+        public String deep(@Arg("x") String x) {
+            return x;
+        }
+    }
+
+    @Command(label = "en")
+    public static class EnumCommand implements CommandService {
+
+        @Executor(pattern = "mode <mode>")
+        public String mode(@Arg("mode") Mode mode) {
+            return mode.name();
+        }
+    }
+
+    @Command(label = "bool")
+    public static class BooleanCommand implements CommandService {
+
+        @Executor(pattern = "flag <on>")
+        public String flag(@Arg("on") boolean on) {
+            return String.valueOf(on);
+        }
+    }
+
+    public enum Mode {
+        SURVIVAL, CREATIVE, ADVENTURE
+    }
+
+    @Command(label = "shared")
+    public static class SharedFirstCommand implements CommandService {
+
+        @Executor(pattern = "first <x>")
+        public String first(@Arg("x") String x) {
+            return x;
+        }
+    }
+
+    @Command(label = "shared")
+    public static class SharedSecondCommand implements CommandService {
+
+        @Executor(pattern = "second <y>")
+        public String second(@Arg("y") String y) {
+            return y;
+        }
+    }
+
+    @BrigadierDisabled
+    @Command(label = "shared")
+    public static class SharedDisabledCommand implements CommandService {
+
+        @Executor(pattern = "third")
+        public String third() {
+            return "third";
+        }
+    }
+
+    @BrigadierDisabled
+    @Command(label = "dis")
+    public static class DisabledCommand implements CommandService {
+
+        @Executor(pattern = "one")
+        public String one() {
+            return "one";
+        }
+    }
+}

--- a/core/src/main/java/eu/okaeri/commands/handler/completion/DefaultCompletionHandler.java
+++ b/core/src/main/java/eu/okaeri/commands/handler/completion/DefaultCompletionHandler.java
@@ -22,7 +22,7 @@ public class DefaultCompletionHandler implements CompletionHandler {
         commands.registerCompletion("default:enum", (completion, argument, invocation, data) ->
             this.completeEnum(invocation, argument.getType(), this.getLimit(argument, invocation)));
         commands.registerCompletion("default:boolean", (completion, argument, invocation, data) ->
-            BOOLEAN_COMPLETIONS);
+            this.completeBoolean(invocation, this.getLimit(argument, invocation)));
     }
 
     protected List<String> completeEnum(@NotNull Invocation invocation, Class<?> type, int limit) {
@@ -30,6 +30,10 @@ public class DefaultCompletionHandler implements CompletionHandler {
             .map(Enum.class::cast)
             .map(Enum::name)
             .map(String::toLowerCase));
+    }
+
+    protected List<String> completeBoolean(@NotNull Invocation invocation, int limit) {
+        return this.filter(limit, this.stringFilter(invocation), BOOLEAN_COMPLETIONS.stream());
     }
 
     @Override
@@ -43,7 +47,7 @@ public class DefaultCompletionHandler implements CompletionHandler {
         }
 
         if (boolean.class.isAssignableFrom(type)) {
-            return BOOLEAN_COMPLETIONS;
+            return this.completeBoolean(invocation, limit);
         }
 
         return Collections.emptyList();

--- a/core/src/main/java/eu/okaeri/commands/meta/pattern/PatternMeta.java
+++ b/core/src/main/java/eu/okaeri/commands/meta/pattern/PatternMeta.java
@@ -234,9 +234,9 @@ public class PatternMeta {
                 }
             }
 
-            // return element if got this far
-            // and is at searched arg index
-            if (argIndex == argAtIndex) {
+            // return element if got this far and the searched arg index falls
+            // anywhere in its span, a wider element covering more than one
+            if ((argAtIndex >= argIndex) && ((element.getWidth() == -1) || (argAtIndex < (argIndex + element.getWidth())))) {
                 return Optional.of(element);
             }
 
@@ -275,7 +275,8 @@ public class PatternMeta {
         for (PatternElement element : elements) {
 
             // no such index in arguments and not optional (missing element)
-            if ((argsArr.length <= patternIndex) && !(element instanceof OptionalElement)) {
+            // counted in arguments, not in elements: a wider element consumes more than one
+            if ((argsArr.length <= argIndex) && !(element instanceof OptionalElement)) {
                 return false;
             }
 

--- a/core/src/test/java/eu/okaeri/commandstest/TestCommandComplete.java
+++ b/core/src/test/java/eu/okaeri/commandstest/TestCommandComplete.java
@@ -63,6 +63,20 @@ public final class TestCommandComplete {
         assertIterableEquals(Collections.singletonList("ask"), this.commands.complete("tab1 join player1 a"));
     }
 
+    @Test
+    public void test_complete_boolean() {
+        assertIterableEquals(Arrays.asList("false", "true"), this.commands.complete("tab1 toggle "));
+        assertIterableEquals(Collections.singletonList("true"), this.commands.complete("tab1 toggle t"));
+        assertIterableEquals(Collections.singletonList("false"), this.commands.complete("tab1 toggle f"));
+        assertIterableEquals(Collections.emptyList(), this.commands.complete("tab1 toggle x"));
+    }
+
+    @Test
+    public void test_complete_enum() {
+        assertIterableEquals(Arrays.asList("all", "none", "some"), this.commands.complete("tab1 mode "));
+        assertIterableEquals(Collections.singletonList("some"), this.commands.complete("tab1 mode s"));
+    }
+
     @Command(label = "tab1")
     public static class TabCompleteCommand implements CommandService {
 
@@ -94,5 +108,19 @@ public final class TestCommandComplete {
         public String _join_ask(@Arg String player) {
             return player;
         }
+
+        @Executor(pattern = "toggle *")
+        public boolean _toggle(@Arg("state") boolean state) {
+            return state;
+        }
+
+        @Executor(pattern = "mode *")
+        public String _mode(@Arg("mode") Mode mode) {
+            return mode.name();
+        }
+    }
+
+    public enum Mode {
+        ALL, NONE, SOME
     }
 }

--- a/core/src/test/java/eu/okaeri/commandstest/TestCommandWideArgs.java
+++ b/core/src/test/java/eu/okaeri/commandstest/TestCommandWideArgs.java
@@ -1,0 +1,78 @@
+package eu.okaeri.commandstest;
+
+import eu.okaeri.commands.Commands;
+import eu.okaeri.commands.OkaeriCommands;
+import eu.okaeri.commands.annotation.Arg;
+import eu.okaeri.commands.annotation.Command;
+import eu.okaeri.commands.annotation.Executor;
+import eu.okaeri.commands.service.CommandService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * An element wider than one consumes several arguments, so the position in the
+ * pattern and the position in the arguments drift apart. Matching used to count
+ * elements while indexing arguments, which both mismatched and, once the drift
+ * ran past the end, threw out of the command handler.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public final class TestCommandWideArgs {
+
+    private Commands commands;
+
+    @BeforeAll
+    public void prepare() {
+        this.commands = new OkaeriCommands();
+        this.commands.registerCommand(WideArgsCommand.class);
+    }
+
+    @Test
+    public void test_match_full_width() {
+        assertTrue(this.commands.invocationMatch("wide set 1 2 now").isPresent());
+    }
+
+    @Test
+    public void test_match_rejects_partial_width() {
+        assertFalse(this.commands.invocationMatch("wide set 1 now").isPresent());
+        assertFalse(this.commands.invocationMatch("wide set 1 2").isPresent());
+        assertFalse(this.commands.invocationMatch("wide set 1").isPresent());
+        assertFalse(this.commands.invocationMatch("wide set 1 2 now extra").isPresent());
+    }
+
+    @Test
+    public void test_complete_inside_a_wide_element() {
+        // the second half of <coords:2>, not the "now" that follows it
+        assertIterableEquals(Collections.emptyList(), this.commands.complete("wide set 1 "));
+        assertIterableEquals(Collections.singletonList("now"), this.commands.complete("wide set 1 2 "));
+    }
+
+    @Test
+    public void test_wide_value_is_joined() throws Exception {
+        assertEquals("1 2", this.commands.call("wide set 1 2 now"));
+    }
+
+    @Test
+    public void test_trailing_wide_element() throws Exception {
+        assertEquals("a b c", this.commands.call("wide tail a b c"));
+        assertFalse(this.commands.invocationMatch("wide tail a b").isPresent());
+    }
+
+    @Command(label = "wide")
+    public static class WideArgsCommand implements CommandService {
+
+        @Executor(pattern = "set <coords:2> now")
+        public String set(@Arg("coords") String coords) {
+            return coords;
+        }
+
+        @Executor(pattern = "tail <rest:3>")
+        public String tail(@Arg("rest") String rest) {
+            return rest;
+        }
+    }
+}


### PR DESCRIPTION
The brigadier mapper turns registered commands into the tree the server sends to a client, so arguments can be coloured and completed locally. It was written against an append-only model of that tree, which brigadier is not, and it had no tests — the module could only be exercised on a live Paper server, so a family of defects accumulated. This reworks the mapping and gives the module its first test suite; #7 is the most visible of the defects it clears, not the whole of it.

`BrigadierTestHarness` rebuilds the node shape CraftBukkit hands to `AsyncPlayerSendCommandsEvent` in memory, so the mapper is now testable with no server. Its parity half replays every fixture back through the engine and asserts the client accepts and completes exactly what the server does — that is what surfaced the two `core` changes here. Splitting those into their own PR would leave the parity suite red in between. One is platform-independent and worth noting on its own: `PatternMeta#matches` threw `ArrayIndexOutOfBoundsException` out of the command handler for any width>1 pattern given short input.

Two divergences are pinned by tests rather than fixed. A literal is matched ahead of a sibling argument and never backtracked, and a greedy element conflicting with a single-word one collapses to word. Both are inherent to brigadier and leave the client stricter than the server, which is the safe direction — the command is still sent and re-parsed server-side.

Worth a second opinion: enum and boolean arguments map to literals so the client can filter offline, but their resolvers accept more than the literals list (both case-insensitive; boolean also takes y/yes/on/1). They now get a plain word node beside the literals so valid input isn't rejected, at the cost of an ask_server round-trip alongside the offline list. Hand-written `@Completion` lists were left strict, on the reasoning that the author picked that exact list.

`@BrigadierDisabled` is still honoured and not removed — its javadoc calls it temporary "while various implementation issues remain unaddressed", and those are largely what this PR addresses, but retiring it is an API break and your call.

Closes #7
