### PR TITLE
feat: narrow executors by declared sender type

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,49 @@ public class ExampleCommand implements CommandService {
 }
 ```
 
+## Sender narrowing
+
+Any executor parameter typed as the platform's sender (`CommandSender` on bukkit/bungee,
+`CommandSource` on velocity) or one of its subtypes is filled with the sender. Declaring a
+*narrower* type restricts the executor to matching senders — no annotation needed:
+
+```java
+@Command(label = "home")
+public class HomeCommand implements CommandService {
+
+    // any sender, console included
+    @Executor
+    public String list(CommandSender sender) { ... }
+
+    // players only
+    @Executor
+    public String set(Player player, @Arg String name) { ... }
+
+    // console only, with a custom message for everyone else
+    @Executor(pattern = "reload")
+    public String reload(@Context(invalid = "${consoleOnly}") ConsoleCommandSender sender) { ... }
+}
+```
+
+Narrowing applies everywhere the command is exposed: tab completion, the generated help, the
+brigadier client tree and the command list sent to players all hide executors the sender cannot
+use. Running one anyway fails with `InvalidContextException`, rendered as *"This command can only
+be executed by {expected}!"*.
+
+`@Context` is only needed to customise that message via `invalid()`, which accepts plain text or an
+`${i18n key}` resolved through the `TextHandler`. Global templates: `${commandSystemContextError}`
+(with `{expected}`) and `${commandSystemContextMessageError}` (with `{message}`).
+
+Two limits worth knowing:
+
+- A sender-typed parameter is owned by narrowing, so it cannot also be supplied by DI or a custom
+  `MissingArgumentHandler` — those still run for every other parameter, and for a sender-typed one
+  whenever there is no sender in the `CommandData` at all (headless `Commands#call`). Annotating it
+  `@Context` opts out of that fallback and always requires a matching sender.
+- Executors are matched by pattern only, so you cannot overload the *same* pattern on sender type
+  and have each get its own executor — the most specific pattern wins and a mismatched sender gets
+  `InvalidContextException`. Give the variants different patterns instead.
+
 ## Recommendations
 
 It is highly recommended to use `-parameters` compiler flag for better overall feature support.

--- a/brigadier/src/main/java/eu/okaeri/commands/brigadier/CommandsBrigadierBase.java
+++ b/brigadier/src/main/java/eu/okaeri/commands/brigadier/CommandsBrigadierBase.java
@@ -134,7 +134,7 @@ public class CommandsBrigadierBase {
 
                 // check access
                 Invocation invocation = Invocation.of(meta, service.getLabel(), "");
-                if (!this.commands.getAccessHandler().allowAccess(executor, invocation, data)) {
+                if (!this.commands.allowExecutor(executor, invocation, data)) {
                     continue;
                 }
 

--- a/bukkit/src/main/java/eu/okaeri/commands/bukkit/CommandsBukkit.java
+++ b/bukkit/src/main/java/eu/okaeri/commands/bukkit/CommandsBukkit.java
@@ -1,13 +1,11 @@
 package eu.okaeri.commands.bukkit;
 
 import eu.okaeri.commands.OkaeriCommands;
-import eu.okaeri.commands.annotation.Context;
 import eu.okaeri.commands.bukkit.annotation.Sender;
 import eu.okaeri.commands.bukkit.handler.*;
 import eu.okaeri.commands.bukkit.listener.AsyncTabCompleteListener;
 import eu.okaeri.commands.bukkit.listener.PlayerCommandSendListener;
 import eu.okaeri.commands.bukkit.type.CommandsBukkitTypes;
-import eu.okaeri.commands.exception.InvalidContextException;
 import eu.okaeri.commands.exception.NoSuchCommandException;
 import eu.okaeri.commands.meta.CommandMeta;
 import eu.okaeri.commands.meta.ExecutorMeta;
@@ -23,8 +21,6 @@ import lombok.Setter;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandMap;
 import org.bukkit.command.CommandSender;
-import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -98,45 +94,14 @@ public class CommandsBukkit extends OkaeriCommands {
     }
 
     @Override
-    public Object resolveMissingArgument(@NonNull Invocation invocation, @NonNull CommandData data, @NonNull CommandMeta command, @NonNull Parameter param, int index) {
-
-        Class<?> paramType = param.getType();
-        Object sender = data.get("sender");
-
-        // player only command
-        if (Player.class.equals(paramType) && ((param.getAnnotation(Context.class) != null) || (param.getAnnotation(Sender.class) != null))) {
-            if (sender instanceof Player) {
-                return sender;
-            }
-            String customInvalid = this.getContextInvalidMessage(param, invocation, data);
-            Class<?> actualType = (sender == null) ? null : sender.getClass();
-            throw new InvalidContextException(customInvalid, Player.class, actualType);
-        }
-
-        // console only command
-        if (ConsoleCommandSender.class.equals(paramType)) {
-            if (sender instanceof ConsoleCommandSender) {
-                return sender;
-            }
-            String customInvalid = this.getContextInvalidMessage(param, invocation, data);
-            Class<?> actualType = (sender == null) ? null : sender.getClass();
-            throw new InvalidContextException(customInvalid, ConsoleCommandSender.class, actualType);
-        }
-
-        // other sender
-        if (CommandSender.class.equals(paramType) && (sender instanceof CommandSender)) {
-            return sender;
-        }
-
-        return super.resolveMissingArgument(invocation, data, command, param, index);
+    public Class<?> getSenderType() {
+        return CommandSender.class;
     }
 
-    protected String getContextInvalidMessage(@NonNull Parameter param, @NonNull Invocation invocation, @NonNull CommandData data) {
-        Context context = param.getAnnotation(Context.class);
-        if ((context != null) && !context.invalid().isEmpty()) {
-            return this.resolveText(invocation, data, context.invalid());
-        }
-        return "";
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isContextRequired(@NonNull Parameter param) {
+        return (param.getAnnotation(Sender.class) != null) || super.isContextRequired(param);
     }
 
     @Override

--- a/bukkit/src/main/java/eu/okaeri/commands/bukkit/listener/PlayerCommandSendListener.java
+++ b/bukkit/src/main/java/eu/okaeri/commands/bukkit/listener/PlayerCommandSendListener.java
@@ -46,7 +46,7 @@ public class PlayerCommandSendListener implements EventExecutor {
         Set<String> disallowedLabels = this.commands.getRegisteredServices().values().stream()
             .filter(service -> {
                 Invocation invocation = Invocation.of(service, service.getLabel(), new String[0]);
-                return !this.commands.getAccessHandler().allowAccess(service, invocation, data);
+                return !this.commands.allowService(service, invocation, data);
             })
             .flatMap(service -> {
                 List<String> labels = new ArrayList<>();

--- a/bungee/src/main/java/eu/okaeri/commands/bungee/CommandsBungee.java
+++ b/bungee/src/main/java/eu/okaeri/commands/bungee/CommandsBungee.java
@@ -1,10 +1,8 @@
 package eu.okaeri.commands.bungee;
 
 import eu.okaeri.commands.OkaeriCommands;
-import eu.okaeri.commands.annotation.Context;
 import eu.okaeri.commands.bungee.handler.*;
 import eu.okaeri.commands.bungee.type.CommandsBungeeTypes;
-import eu.okaeri.commands.exception.InvalidContextException;
 import eu.okaeri.commands.exception.NoSuchCommandException;
 import eu.okaeri.commands.meta.CommandMeta;
 import eu.okaeri.commands.meta.ExecutorMeta;
@@ -19,12 +17,10 @@ import lombok.NonNull;
 import lombok.Setter;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.TabExecutor;
 
-import java.lang.reflect.Parameter;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -70,35 +66,8 @@ public class CommandsBungee extends OkaeriCommands {
     }
 
     @Override
-    public Object resolveMissingArgument(@NonNull Invocation invocation, @NonNull CommandData data, @NonNull CommandMeta command, @NonNull Parameter param, int index) {
-
-        Class<?> paramType = param.getType();
-        Object sender = data.get("sender");
-
-        // player only command
-        if (ProxiedPlayer.class.equals(paramType) && (param.getAnnotation(Context.class) != null)) {
-            if (sender instanceof ProxiedPlayer) {
-                return sender;
-            }
-            String customInvalid = this.getContextInvalidMessage(param, invocation, data);
-            Class<?> actualType = (sender == null) ? null : sender.getClass();
-            throw new InvalidContextException(customInvalid, ProxiedPlayer.class, actualType);
-        }
-
-        // other sender (allows both console and players)
-        if (CommandSender.class.equals(paramType) && (sender instanceof CommandSender)) {
-            return sender;
-        }
-
-        return super.resolveMissingArgument(invocation, data, command, param, index);
-    }
-
-    protected String getContextInvalidMessage(@NonNull Parameter param, @NonNull Invocation invocation, @NonNull CommandData data) {
-        Context context = param.getAnnotation(Context.class);
-        if ((context != null) && !context.invalid().isEmpty()) {
-            return this.resolveText(invocation, data, context.invalid());
-        }
-        return "";
+    public Class<?> getSenderType() {
+        return CommandSender.class;
     }
 
     @Override

--- a/core/src/main/java/eu/okaeri/commands/Commands.java
+++ b/core/src/main/java/eu/okaeri/commands/Commands.java
@@ -1,5 +1,6 @@
 package eu.okaeri.commands;
 
+import eu.okaeri.commands.annotation.Context;
 import eu.okaeri.commands.handler.access.AccessHandler;
 import eu.okaeri.commands.handler.argument.MissingArgumentHandler;
 import eu.okaeri.commands.handler.completion.CompletionHandler;
@@ -11,7 +12,10 @@ import eu.okaeri.commands.handler.scheduling.SchedulingHandler;
 import eu.okaeri.commands.handler.text.TextHandler;
 import eu.okaeri.commands.handler.validation.ParameterValidationHandler;
 import eu.okaeri.commands.meta.CommandMeta;
+import eu.okaeri.commands.meta.ContextMeta;
+import eu.okaeri.commands.meta.ExecutorMeta;
 import eu.okaeri.commands.meta.InvocationMeta;
+import eu.okaeri.commands.meta.ServiceMeta;
 import eu.okaeri.commands.service.CommandData;
 import eu.okaeri.commands.service.CommandService;
 import eu.okaeri.commands.service.Invocation;
@@ -105,6 +109,95 @@ public interface Commands extends Closeable {
     String resolveText(@NonNull Invocation invocation, @NonNull CommandData data, @NonNull String text);
 
     Object resolveMissingArgument(@NonNull Invocation invocation, @NonNull CommandData data, @NonNull CommandMeta command, @NonNull Parameter param, int i);
+
+    /**
+     * Base type of this platform's command sender, e.g. {@code CommandSender} on bukkit.
+     * Any executor parameter assignable to it narrows the executor to matching senders.
+     *
+     * @return the sender base type, or null on platforms without a sender concept
+     */
+    default Class<?> getSenderType() {
+        return null;
+    }
+
+    /**
+     * Only the declared type decides this - an annotation cannot turn a parameter the sender could
+     * never satisfy into a context parameter, or {@code @Context SomeService} would stop reaching
+     * the {@link MissingArgumentHandler} and fail with a nonsensical "can only be executed by
+     * SomeService" instead.
+     *
+     * @return true when the parameter is to be filled with the sender from the command data
+     */
+    default boolean isContextParameter(@NonNull Parameter param) {
+        Class<?> senderType = this.getSenderType();
+        return (senderType != null) && senderType.isAssignableFrom(param.getType());
+    }
+
+    /**
+     * Whether a context parameter opts into the sender explicitly, as opposed to being narrowed by
+     * its declared type alone. A required parameter is enforced even when the data carries no
+     * sender; a type-derived one falls back to the {@link MissingArgumentHandler} instead.
+     *
+     * <p>Only consulted for parameters {@link #isContextParameter(Parameter)} already accepted.</p>
+     *
+     * @return true when the parameter is explicitly annotated as a context parameter
+     */
+    default boolean isContextRequired(@NonNull Parameter param) {
+        return param.getAnnotation(Context.class) != null;
+    }
+
+    /**
+     * @return true when the sender in the data satisfies every context parameter of the executor
+     */
+    default boolean allowContext(@NonNull ExecutorMeta executor, @NonNull CommandData data) {
+
+        List<ContextMeta> contexts = executor.getContexts();
+        if (contexts.isEmpty()) {
+            return true;
+        }
+
+        // nothing to narrow against, let the invocation decide
+        Object sender = data.get(CommandData.SENDER);
+        if (sender == null) {
+            return true;
+        }
+
+        return contexts.stream().allMatch(context -> context.accepts(sender));
+    }
+
+    /**
+     * Checks every executor registered under the service's <i>label</i> — several services may share
+     * one label, and a label is a single client-visible unit.
+     *
+     * @return true when at least one executor under the label accepts the sender
+     */
+    default boolean allowContext(@NonNull ServiceMeta service, @NonNull CommandData data) {
+        return this.findByLabel(service.getLabel()).stream()
+            .anyMatch(command -> this.allowContext(command.getExecutor(), data));
+    }
+
+    /**
+     * Both gates every surface exposing an executor has to pass: permissions and sender narrowing.
+     */
+    default boolean allowExecutor(@NonNull ExecutorMeta executor, @NonNull Invocation invocation, @NonNull CommandData data) {
+        return this.getAccessHandler().allowAccess(executor, invocation, data)
+            && this.allowContext(executor, data);
+    }
+
+    /**
+     * @see #allowExecutor(ExecutorMeta, Invocation, CommandData)
+     */
+    default boolean allowService(@NonNull ServiceMeta service, @NonNull Invocation invocation, @NonNull CommandData data) {
+        return this.allowService(service, invocation, data, true);
+    }
+
+    /**
+     * @see #allowExecutor(ExecutorMeta, Invocation, CommandData)
+     */
+    default boolean allowService(@NonNull ServiceMeta service, @NonNull Invocation invocation, @NonNull CommandData data, boolean checkExecutors) {
+        return this.getAccessHandler().allowAccess(service, invocation, data, checkExecutors)
+            && this.allowContext(service, data);
+    }
 
     List<CommandMeta> findByLabel(@NonNull String label);
 

--- a/core/src/main/java/eu/okaeri/commands/OkaeriCommands.java
+++ b/core/src/main/java/eu/okaeri/commands/OkaeriCommands.java
@@ -1,9 +1,11 @@
 package eu.okaeri.commands;
 
 import eu.okaeri.commands.annotation.Arg;
+import eu.okaeri.commands.annotation.Context;
 import eu.okaeri.commands.annotation.Executor;
 import eu.okaeri.commands.annotation.Label;
 import eu.okaeri.commands.annotation.RawArgs;
+import eu.okaeri.commands.exception.InvalidContextException;
 import eu.okaeri.commands.exception.NoSuchCommandException;
 import eu.okaeri.commands.handler.access.AccessHandler;
 import eu.okaeri.commands.handler.access.DefaultAccessHandler;
@@ -308,6 +310,33 @@ public class OkaeriCommands implements Commands {
 
     @Override
     public Object resolveMissingArgument(@NonNull Invocation invocation, @NonNull CommandData data, @NonNull CommandMeta command, @NonNull Parameter param, int index) {
+
+        ContextMeta context = command.getExecutor().getContexts().stream()
+            .filter(meta -> meta.getIndex() == index)
+            .findFirst()
+            .orElse(null);
+
+        if (context != null) {
+
+            Object sender = data.get(CommandData.SENDER);
+            if (context.accepts(sender)) {
+                return sender;
+            }
+
+            // narrowed by its declared type alone and there is no sender to narrow against
+            // (headless Commands#call, programmatic use) - leave it to the handler, as before
+            if (!context.isRequired() && (sender == null)) {
+                return this.getMissingArgumentHandler().resolve(invocation, data, command, param, index);
+            }
+
+            String customInvalid = context.getInvalid().isEmpty()
+                ? ""
+                : this.resolveText(invocation, data, context.getInvalid());
+
+            Class<?> actualType = (sender == null) ? null : sender.getClass();
+            throw new InvalidContextException(customInvalid, context.getType(), actualType);
+        }
+
         return this.getMissingArgumentHandler().resolve(invocation, data, command, param, index);
     }
 
@@ -386,7 +415,7 @@ public class OkaeriCommands implements Commands {
             }
 
             ExecutorMeta executor = meta.getExecutor();
-            if (!this.getAccessHandler().allowAccess(executor, localInvocation, data)) {
+            if (!this.allowExecutor(executor, localInvocation, data)) {
                 continue;
             }
 

--- a/core/src/main/java/eu/okaeri/commands/help/HelpBuilder.java
+++ b/core/src/main/java/eu/okaeri/commands/help/HelpBuilder.java
@@ -49,7 +49,7 @@ public abstract class HelpBuilder {
             .findByLabel(invocation.getLabel())
             .stream()
             .filter(meta -> meta.getExecutor().getIndex() == 0)
-            .filter(meta -> commands.getAccessHandler().allowAccess(meta.getExecutor(), invocation, data))
+            .filter(meta -> commands.allowExecutor(meta.getExecutor(), invocation, data))
             .sorted(Comparator.comparing(meta -> meta.getExecutor().getPattern().getRaw()))
             .collect(Collectors.groupingBy(meta -> meta.getExecutor().getPattern().getRaw().split(" ")[0]))
             .values()

--- a/core/src/main/java/eu/okaeri/commands/meta/ContextMeta.java
+++ b/core/src/main/java/eu/okaeri/commands/meta/ContextMeta.java
@@ -1,0 +1,40 @@
+package eu.okaeri.commands.meta;
+
+import eu.okaeri.commands.Commands;
+import eu.okaeri.commands.annotation.Context;
+import lombok.Data;
+import lombok.NonNull;
+
+import java.lang.reflect.Parameter;
+
+/**
+ * One per executor parameter filled with the sender from the {@link eu.okaeri.commands.service.CommandData}.
+ */
+@Data
+public class ContextMeta {
+
+    private Class<?> type;
+    private boolean required;
+    private String invalid;
+    private int index;
+
+    public static ContextMeta of(@NonNull Commands commands, @NonNull Parameter parameter, int index) {
+
+        ContextMeta meta = new ContextMeta();
+        meta.type = parameter.getType();
+        meta.index = index;
+
+        // an explicitly annotated parameter is enforced even when there is no sender at all,
+        // a parameter narrowed by its declared type alone falls back to the MissingArgumentHandler
+        meta.required = commands.isContextRequired(parameter);
+
+        Context context = parameter.getAnnotation(Context.class);
+        meta.invalid = (context == null) ? "" : context.invalid();
+
+        return meta;
+    }
+
+    public boolean accepts(Object sender) {
+        return this.type.isInstance(sender);
+    }
+}

--- a/core/src/main/java/eu/okaeri/commands/meta/ExecutorMeta.java
+++ b/core/src/main/java/eu/okaeri/commands/meta/ExecutorMeta.java
@@ -23,6 +23,7 @@ public class ExecutorMeta {
 
     private Method method;
     private List<ArgumentMeta> arguments;
+    private List<ContextMeta> contexts;
     private PatternMeta pattern;
     private CompletionMeta completion;
     private String description;
@@ -54,14 +55,19 @@ public class ExecutorMeta {
                 cmdExecutor.method = method;
 
                 List<ArgumentMeta> arguments = new ArrayList<>();
+                List<ContextMeta> contexts = new ArrayList<>();
                 for (int i = 0; i < method.getParameters().length; i++) {
                     Parameter parameter = method.getParameters()[i];
-                    if (!ArgumentMeta.isArg(parameter)) {
+                    if (ArgumentMeta.isArg(parameter)) {
+                        arguments.add(ArgumentMeta.of(commands, parameter, i));
                         continue;
                     }
-                    arguments.add(ArgumentMeta.of(commands, parameter, i));
+                    if (commands.isContextParameter(parameter)) {
+                        contexts.add(ContextMeta.of(commands, parameter, i));
+                    }
                 }
                 cmdExecutor.arguments = Collections.unmodifiableList(arguments);
+                cmdExecutor.contexts = Collections.unmodifiableList(contexts);
 
                 cmdExecutor.pattern = PatternMeta.of(commands, patternPrefix, pattern, cmdExecutor.arguments, emptyPattern);
                 cmdExecutor.completion = CompletionMeta.of(commands, method);

--- a/core/src/main/java/eu/okaeri/commands/service/CommandData.java
+++ b/core/src/main/java/eu/okaeri/commands/service/CommandData.java
@@ -9,6 +9,11 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class CommandData {
 
+    /**
+     * Key under which every platform adapter stores the command sender.
+     */
+    public static final String SENDER = "sender";
+
     private final Map<String, Object> metadata = new LinkedHashMap<>();
 
     public boolean has(String key) {

--- a/core/src/test/java/eu/okaeri/commandstest/TestSenderNarrowing.java
+++ b/core/src/test/java/eu/okaeri/commandstest/TestSenderNarrowing.java
@@ -1,0 +1,227 @@
+package eu.okaeri.commandstest;
+
+import eu.okaeri.commands.OkaeriCommands;
+import eu.okaeri.commands.annotation.Command;
+import eu.okaeri.commands.annotation.Context;
+import eu.okaeri.commands.annotation.Executor;
+import eu.okaeri.commands.exception.InvalidContextException;
+import eu.okaeri.commands.handler.argument.DefaultMissingArgumentHandler;
+import eu.okaeri.commands.meta.CommandMeta;
+import eu.okaeri.commands.meta.ContextMeta;
+import eu.okaeri.commands.meta.InvocationMeta;
+import eu.okaeri.commands.service.CommandData;
+import eu.okaeri.commands.service.CommandService;
+import eu.okaeri.commands.service.Invocation;
+import eu.okaeri.commandstest.command.SenderNarrowingCommand;
+import eu.okaeri.commandstest.sender.TestConsole;
+import eu.okaeri.commandstest.sender.TestPlayer;
+import eu.okaeri.commandstest.sender.TestSender;
+import lombok.NonNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public final class TestSenderNarrowing {
+
+    private static final TestPlayer PLAYER = new TestPlayer("Steve");
+    private static final TestConsole CONSOLE = new TestConsole();
+
+    private OkaeriCommands commands;
+
+    /**
+     * Stands in for a platform adapter: the only thing a platform has to declare is its sender base type.
+     */
+    private static class TestPlatformCommands extends OkaeriCommands {
+        @Override
+        public Class<?> getSenderType() {
+            return TestSender.class;
+        }
+    }
+
+    @BeforeAll
+    public void prepare() {
+        this.commands = new TestPlatformCommands();
+        this.commands.registerCommand(SenderNarrowingCommand.class);
+    }
+
+    private CommandData data(Object sender) {
+        CommandData data = new CommandData();
+        if (sender != null) {
+            data.add(CommandData.SENDER, sender);
+        }
+        return data;
+    }
+
+    private Object call(String command, Object sender) throws Exception {
+        CommandData data = this.data(sender);
+        Invocation invocation = this.commands.invocationMatch(command)
+            .orElseThrow(() -> new AssertionError("no executor for '" + command + "'"));
+        InvocationMeta invocationMeta = this.commands.invocationPrepare(invocation, data);
+        return invocationMeta.call();
+    }
+
+    private List<String> complete(String command, Object sender) {
+        String[] parts = command.split(" ", 2);
+        String label = parts[0];
+        String args = (parts.length > 1) ? parts[1] : "";
+        List<CommandMeta> metas = this.commands.findByLabel(label);
+        return this.commands.complete(metas, Invocation.of(label, args), this.data(sender));
+    }
+
+    private ContextMeta onlyContext(String command) {
+        List<ContextMeta> contexts = this.commands.findByLabelAndArgs("narrow", command)
+            .orElseThrow(AssertionError::new)
+            .getExecutor().getContexts();
+        assertEquals(1, contexts.size());
+        return contexts.get(0);
+    }
+
+    @Test
+    public void test_contexts_collected_without_annotation() {
+        // narrowing is driven by the declared type, @Context is not required
+        ContextMeta derived = this.onlyContext("player");
+        assertEquals(TestPlayer.class, derived.getType());
+        assertFalse(derived.isRequired());
+
+        // annotating opts in explicitly, which is enforced even without a sender
+        ContextMeta annotated = this.onlyContext("annotated");
+        assertEquals(TestPlayer.class, annotated.getType());
+        assertTrue(annotated.isRequired());
+
+        // a plain @Arg executor narrows nothing
+        assertTrue(this.commands.findByLabelAndArgs("narrow", "plain x").orElseThrow(AssertionError::new)
+            .getExecutor().getContexts().isEmpty());
+    }
+
+    @Test
+    public void test_sender_is_passed_when_type_matches() throws Exception {
+        assertEquals("player:Steve", this.call("narrow player", PLAYER));
+        assertEquals("console", this.call("narrow console", CONSOLE));
+        // base type accepts every sender
+        assertEquals("any:Steve", this.call("narrow any", PLAYER));
+        assertEquals("any:CONSOLE", this.call("narrow any", CONSOLE));
+    }
+
+    @Test
+    public void test_mismatched_sender_throws_instead_of_passing_null() {
+        InvalidContextException exception = assertThrows(InvalidContextException.class, () -> this.call("narrow player", CONSOLE));
+        assertEquals(TestPlayer.class, exception.getExpectedType());
+        assertEquals(TestConsole.class, exception.getActualType());
+    }
+
+    @Test
+    public void test_annotated_context_is_enforced_even_without_a_sender() {
+        InvalidContextException exception = assertThrows(InvalidContextException.class, () -> this.call("narrow annotated", null));
+        assertEquals(TestPlayer.class, exception.getExpectedType());
+        assertNull(exception.getActualType());
+    }
+
+    /**
+     * A type-derived context parameter has nothing to narrow against when the data carries no sender
+     * (headless {@code Commands#call}), so it must keep falling through to the MissingArgumentHandler -
+     * that is the extension point the injector module resolves DI through.
+     */
+    @Test
+    public void test_type_derived_context_falls_through_to_the_missing_argument_handler() throws Exception {
+
+        OkaeriCommands commands = new TestPlatformCommands();
+        commands.missingArgumentHandler(new DefaultMissingArgumentHandler() {
+            @Override
+            public Object resolve(@NonNull Invocation invocation, @NonNull CommandData data, @NonNull CommandMeta command, @NonNull Parameter param, int index) {
+                if (TestSender.class.isAssignableFrom(param.getType())) {
+                    return new TestPlayer("FromDI");
+                }
+                return super.resolve(invocation, data, command, param, index);
+            }
+        });
+        commands.registerCommand(SenderNarrowingCommand.class);
+
+        assertEquals("player:FromDI", commands.call("narrow player"));
+    }
+
+    /**
+     * ...but a sender that is present and of the wrong type is a narrowing failure, not a
+     * resolution gap, so the handler must not get a chance to paper over it.
+     */
+    @Test
+    public void test_present_but_wrong_sender_is_not_delegated_to_the_handler() {
+
+        OkaeriCommands commands = new TestPlatformCommands();
+        commands.missingArgumentHandler(new DefaultMissingArgumentHandler() {
+            @Override
+            public Object resolve(@NonNull Invocation invocation, @NonNull CommandData data, @NonNull CommandMeta command, @NonNull Parameter param, int index) {
+                return new TestPlayer("FromDI");
+            }
+        });
+        commands.registerCommand(SenderNarrowingCommand.class);
+
+        CommandData data = new CommandData();
+        data.add(CommandData.SENDER, CONSOLE);
+        Invocation invocation = commands.invocationMatch("narrow player").orElseThrow(AssertionError::new);
+
+        assertThrows(InvalidContextException.class, () -> commands.invocationPrepare(invocation, data).call());
+    }
+
+    public static class Injected {
+    }
+
+    @Command(label = "annotatedNonSender")
+    public static class AnnotatedNonSenderCommand implements CommandService {
+        @Executor
+        public String go(@Context Injected injected) {
+            return "go:" + ((injected == null) ? "null" : "injected");
+        }
+    }
+
+    /**
+     * {@code @Context} marks strictness, not membership: a type the sender could never satisfy is
+     * not a context parameter at all, so it keeps reaching the MissingArgumentHandler. Otherwise the
+     * annotation would break DI and report "can only be executed by Injected".
+     */
+    @Test
+    public void test_annotation_does_not_capture_a_non_sender_type() throws Exception {
+
+        OkaeriCommands commands = new TestPlatformCommands();
+        commands.missingArgumentHandler(new DefaultMissingArgumentHandler() {
+            @Override
+            public Object resolve(@NonNull Invocation invocation, @NonNull CommandData data, @NonNull CommandMeta command, @NonNull Parameter param, int index) {
+                return (param.getType() == Injected.class) ? new Injected() : super.resolve(invocation, data, command, param, index);
+            }
+        });
+        commands.registerCommand(AnnotatedNonSenderCommand.class);
+
+        assertTrue(commands.findByLabelAndArgs("annotatedNonSender", "go").orElseThrow(AssertionError::new)
+            .getExecutor().getContexts().isEmpty());
+        assertEquals("go:injected", commands.call("annotatedNonSender go"));
+    }
+
+    @Test
+    public void test_custom_invalid_message_is_resolved() {
+        InvalidContextException exception = assertThrows(InvalidContextException.class, () -> this.call("narrow annotated", CONSOLE));
+        assertEquals("players only!", exception.getMessage());
+    }
+
+    @Test
+    public void test_completions_are_narrowed_to_the_sender() {
+        assertIterableEquals(Arrays.asList("annotated", "any", "plain", "player"), this.complete("narrow ", PLAYER));
+        assertIterableEquals(Arrays.asList("any", "console", "plain"), this.complete("narrow ", CONSOLE));
+        // no sender in the context, nothing to narrow against
+        assertIterableEquals(Arrays.asList("annotated", "any", "console", "plain", "player"), this.complete("narrow ", null));
+    }
+
+    @Test
+    public void test_service_is_allowed_when_any_executor_accepts_the_sender() {
+        assertTrue(this.commands.allowContext(this.commands.findByLabel("narrow").get(0).getService(), this.data(PLAYER)));
+        assertTrue(this.commands.allowContext(this.commands.findByLabel("narrow").get(0).getService(), this.data(CONSOLE)));
+        // a sender the service knows nothing about matches only the executors without narrowing
+        assertTrue(this.commands.allowContext(this.commands.findByLabel("narrow").get(0).getService(), this.data("stranger")));
+    }
+}

--- a/core/src/test/java/eu/okaeri/commandstest/command/SenderNarrowingCommand.java
+++ b/core/src/test/java/eu/okaeri/commandstest/command/SenderNarrowingCommand.java
@@ -1,0 +1,39 @@
+package eu.okaeri.commandstest.command;
+
+import eu.okaeri.commands.annotation.Arg;
+import eu.okaeri.commands.annotation.Command;
+import eu.okaeri.commands.annotation.Context;
+import eu.okaeri.commands.annotation.Executor;
+import eu.okaeri.commands.service.CommandService;
+import eu.okaeri.commandstest.sender.TestConsole;
+import eu.okaeri.commandstest.sender.TestPlayer;
+import eu.okaeri.commandstest.sender.TestSender;
+
+@Command(label = "narrow")
+public class SenderNarrowingCommand implements CommandService {
+
+    @Executor
+    public String player(TestPlayer sender) {
+        return "player:" + sender.getName();
+    }
+
+    @Executor
+    public String console(TestConsole sender) {
+        return "console";
+    }
+
+    @Executor
+    public String any(TestSender sender) {
+        return "any:" + sender.getName();
+    }
+
+    @Executor
+    public String annotated(@Context(invalid = "players only!") TestPlayer sender) {
+        return "annotated:" + sender.getName();
+    }
+
+    @Executor
+    public String plain(@Arg String value) {
+        return "plain:" + value;
+    }
+}

--- a/core/src/test/java/eu/okaeri/commandstest/sender/TestConsole.java
+++ b/core/src/test/java/eu/okaeri/commandstest/sender/TestConsole.java
@@ -1,0 +1,9 @@
+package eu.okaeri.commandstest.sender;
+
+public class TestConsole implements TestSender {
+
+    @Override
+    public String getName() {
+        return "CONSOLE";
+    }
+}

--- a/core/src/test/java/eu/okaeri/commandstest/sender/TestPlayer.java
+++ b/core/src/test/java/eu/okaeri/commandstest/sender/TestPlayer.java
@@ -1,0 +1,9 @@
+package eu.okaeri.commandstest.sender;
+
+import lombok.Value;
+
+@Value
+public class TestPlayer implements TestSender {
+
+    String name;
+}

--- a/core/src/test/java/eu/okaeri/commandstest/sender/TestSender.java
+++ b/core/src/test/java/eu/okaeri/commandstest/sender/TestSender.java
@@ -1,0 +1,9 @@
+package eu.okaeri.commandstest.sender;
+
+/**
+ * Stand-in for a platform sender hierarchy (bukkit CommandSender/Player/ConsoleCommandSender).
+ */
+public interface TestSender {
+
+    String getName();
+}

--- a/velocity/src/main/java/eu/okaeri/commands/velocity/CommandsVelocity.java
+++ b/velocity/src/main/java/eu/okaeri/commands/velocity/CommandsVelocity.java
@@ -4,12 +4,8 @@ import com.velocitypowered.api.command.Command;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.command.SimpleCommand;
 import com.velocitypowered.api.plugin.PluginContainer;
-import com.velocitypowered.api.proxy.ConsoleCommandSource;
-import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import eu.okaeri.commands.OkaeriCommands;
-import eu.okaeri.commands.annotation.Context;
-import eu.okaeri.commands.exception.InvalidContextException;
 import eu.okaeri.commands.exception.NoSuchCommandException;
 import eu.okaeri.commands.meta.CommandMeta;
 import eu.okaeri.commands.meta.ExecutorMeta;
@@ -29,7 +25,6 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 
-import java.lang.reflect.Parameter;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -77,44 +72,8 @@ public class CommandsVelocity extends OkaeriCommands {
     }
 
     @Override
-    public Object resolveMissingArgument(@NonNull Invocation invocation, @NonNull CommandData data, @NonNull CommandMeta command, @NonNull Parameter param, int index) {
-
-        Class<?> paramType = param.getType();
-        Object sender = data.get("sender");
-
-        // player only command
-        if (Player.class.equals(paramType) && (param.getAnnotation(Context.class) != null)) {
-            if (sender instanceof Player) {
-                return sender;
-            }
-            String customInvalid = this.getContextInvalidMessage(param, invocation, data);
-            Class<?> actualType = (sender == null) ? null : sender.getClass();
-            throw new InvalidContextException(customInvalid, Player.class, actualType);
-        }
-
-        // console only command
-        if (ConsoleCommandSource.class.equals(paramType) && (param.getAnnotation(Context.class) != null)) {
-            if (sender instanceof ConsoleCommandSource) {
-                return sender;
-            }
-            String customInvalid = this.getContextInvalidMessage(param, invocation, data);
-            Class<?> actualType = (sender == null) ? null : sender.getClass();
-            throw new InvalidContextException(customInvalid, ConsoleCommandSource.class, actualType);
-        }
-
-        if (CommandSource.class.equals(paramType) && (sender instanceof CommandSource)) {
-            return sender;
-        }
-
-        return super.resolveMissingArgument(invocation, data, command, param, index);
-    }
-
-    protected String getContextInvalidMessage(@NonNull Parameter param, @NonNull Invocation invocation, @NonNull CommandData data) {
-        Context context = param.getAnnotation(Context.class);
-        if ((context != null) && !context.invalid().isEmpty()) {
-            return this.resolveText(invocation, data, context.invalid());
-        }
-        return "";
+    public Class<?> getSenderType() {
+        return CommandSource.class;
     }
 
     @Override


### PR DESCRIPTION
Closes #3.

Each platform adapter matched senders against a hardcoded set of exact classes,
so a parameter typed `Entity`, `BlockCommandSender` or any custom subinterface
fell through to the `MissingArgumentHandler` and reached the executor as `null`
— an NPE in user code instead of an explanation. Matching is now by
assignability against a single `getSenderType()` per platform, which also
settles the adapters' disagreement over whether `@Context` was required.

Narrowing drives visibility too: `allowExecutor`/`allowService` pair it with
`AccessHandler#allowAccess`, and completion, help, the brigadier mapper and
`PlayerCommandSendListener` all go through those, so an executor the sender
cannot use is hidden from tab completion, help, the client tree and the command
list. Narrowing is deliberately kept out of `AccessHandler`: handlers here are
replaced rather than composed — `CommandsGuard` installs one whose `allowAccess`
returns `true` unconditionally — so folding it in would silently disable it for
anyone using the acl module.

Resolution stays inside `resolveMissingArgument`, where all three adapters
already did this on master. A context parameter narrowed *by type alone* still
falls through to the `MissingArgumentHandler` when the `CommandData` carries no
sender at all, which keeps headless `Commands#call` and the injector module's DI
working; annotating it `@Context` demands a sender unconditionally. A sender
that is present but of the wrong type always throws and is never delegated, so
DI can't quietly satisfy an executor the visibility layer is hiding.

`@Context` marks strictness, not membership — membership is decided by the
declared type alone. Annotating a type the sender could never satisfy (`@Context
SomeService`) leaves it to the `MissingArgumentHandler` exactly as before, rather
than capturing it and reporting "can only be executed by SomeService".

**Breaking for downstream:** one case only — an *unannotated*
`Player`/`ConsoleCommandSource`-typed parameter now narrows instead of resolving
through DI, whenever a sender is present. Existing `@Context` usage on
sender types behaves as it did. Everything added to `Commands` is a `default`
method, so the interface gains no abstract members and external implementors
stay source-compatible.

Two limits are documented in the README rather than fixed: DI can't supply a
sender-typed parameter while a sender is present, and dispatch is sender-blind
(`invocationMatch` never sees `CommandData`), so the same pattern can't be
overloaded on sender type. The bukkit module has no test sources, so its binding
(`getSenderType`, the deprecated `@Sender` opt-in) is unverified; the logic
itself is covered in core against a fake platform.
